### PR TITLE
claude/fix-late-night-event-validation-jACaF

### DIFF
--- a/src/components/EditRequestModal.jsx
+++ b/src/components/EditRequestModal.jsx
@@ -8,7 +8,6 @@ import {
   isoToLocal,
   toArray,
   isValidUrl,
-  validateTimeOrder,
 } from "../utils/eventFormUtils";
 import { ModalShell, ModalCloseButton } from "./form/ModalShell";
 import { AutocompleteInput } from "./form/AutocompleteInput";
@@ -89,8 +88,6 @@ export default function EditRequestModal({
       if (!f.location.trim()) errs.location = "장소를 입력해주세요.";
       if (f.genre.length === 0) errs.genre = "장르를 하나 이상 선택해주세요.";
       if (f.event_url && !isValidUrl(f.event_url)) errs.event_url = "올바른 URL 형식이 아닙니다. (https://...)";
-      const timeErr = validateTimeOrder(f);
-      if (timeErr) errs.time = timeErr;
       if (!hasChanges) errs.changes = "변경된 내용이 없습니다.";
     }
     return errs;

--- a/src/components/ReportEventModal.jsx
+++ b/src/components/ReportEventModal.jsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useEventForm } from "../hooks/useEventForm";
 import { useAuth } from "../contexts/AuthContext";
-import { buildSubmitData, inputClass, isValidUrl, validateTimeOrder } from "../utils/eventFormUtils";
+import { buildSubmitData, inputClass, isValidUrl } from "../utils/eventFormUtils";
 import { ModalShell, ModalCloseButton } from "./form/ModalShell";
 import { AutocompleteInput } from "./form/AutocompleteInput";
 import { LocationField } from "./form/LocationField";
@@ -51,8 +51,6 @@ export default function ReportEventModal({
     } else if (!isValidUrl(f.event_url)) {
       errs.event_url = "올바른 URL 형식이 아닙니다. (https://...)";
     }
-    const timeErr = validateTimeOrder(f);
-    if (timeErr) errs.time = timeErr;
     return errs;
   };
 

--- a/src/components/admin/EventEditModal.jsx
+++ b/src/components/admin/EventEditModal.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useEventForm } from "../../hooks/useEventForm";
-import { buildSubmitData, inputClass, isValidUrl, validateTimeOrder } from "../../utils/eventFormUtils";
+import { buildSubmitData, inputClass, isValidUrl } from "../../utils/eventFormUtils";
 import { ModalShell, ModalCloseButton } from "../form/ModalShell";
 import { AutocompleteInput } from "../form/AutocompleteInput";
 import { LocationField } from "../form/LocationField";
@@ -43,8 +43,6 @@ export default function EventEditModal({
             errs.event_url = "올바른 URL 형식이 아닙니다. (https://...)";
         }
         if (img && !isValidUrl(img)) errs.img_url = "올바른 URL 형식이 아닙니다. (https://...)";
-        const timeErr = validateTimeOrder(f);
-        if (timeErr) errs.time = timeErr;
         return errs;
     };
 

--- a/src/utils/eventFormUtils.js
+++ b/src/utils/eventFormUtils.js
@@ -66,13 +66,6 @@ export const isValidUrl = url => {
     }
 };
 
-export const validateTimeOrder = ({ time_entrance, time_start }) => {
-    const toMin = t => { const [h, m] = t.split(":").map(Number); return h * 60 + m; };
-    if (time_entrance && time_start && toMin(time_entrance) > toMin(time_start))
-        return "입장 시간이 시작 시간보다 늦습니다.";
-    return null;
-};
-
 /** Transforms common form fields into Firebase-ready data.
  *  Does NOT handle confirm, img_url, reason — each modal manages those. */
 export const buildSubmitData = form => {


### PR DESCRIPTION
Late-night events where entrance is at e.g. 23:40 and the event starts
at 00:00 (next day) were incorrectly blocked. Removed the validation
entirely since midnight-crossing events are a valid use case.

https://claude.ai/code/session_01CEKWpCG6aQXb6vh5gZGrm3