### PR TITLE
fix: upgrade react-router-dom to 7.17.0 to resolve high severity CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1856,19 +1856,18 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+            "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/fetch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+            "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@protobufjs/aspromise": "^1.1.1",
-                "@protobufjs/inquire": "^1.1.0"
+                "@protobufjs/aspromise": "^1.1.1"
             }
         },
         "node_modules/@protobufjs/float": {
@@ -1878,9 +1877,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/inquire": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-            "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+            "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
@@ -4845,24 +4844,24 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.5.6",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-            "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
+            "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
                 "@protobufjs/codegen": "^2.0.5",
-                "@protobufjs/eventemitter": "^1.1.0",
-                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/eventemitter": "^1.1.1",
+                "@protobufjs/fetch": "^1.1.1",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.2",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
                 "@protobufjs/utf8": "^1.1.1",
                 "@types/node": ">=13.7.0",
-                "long": "^5.0.0"
+                "long": "^5.3.2"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -4951,9 +4950,9 @@
             }
         },
         "node_modules/react-router": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.12.0.tgz",
-            "integrity": "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+            "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
             "license": "MIT",
             "dependencies": {
                 "cookie": "^1.0.1",
@@ -4973,12 +4972,12 @@
             }
         },
         "node_modules/react-router-dom": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.12.0.tgz",
-            "integrity": "sha512-pfO9fiBcpEfX4Tx+iTYKDtPbrSLLCbwJ5EqP+SPYQu1VYCXdy79GSj0wttR0U4cikVdlImZuEZ/9ZNCgoaxwBA==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+            "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
             "license": "MIT",
             "dependencies": {
-                "react-router": "7.12.0"
+                "react-router": "7.17.0"
             },
             "engines": {
                 "node": ">=20.0.0"


### PR DESCRIPTION
CI audit 스텝(--audit-level=high) 실패 원인 해소.
react-router 7.0.0~7.14.2 구간의 RCE/XSS/open-redirect 취약점 패치 버전으로 업데이트.