### PR TITLE
fix: add legacy-peer-deps to functions/.npmrc for firebase-admin v14

### DIFF
--- a/functions/.npmrc
+++ b/functions/.npmrc
@@ -1,1 +1,2 @@
 omit=optional
+legacy-peer-deps=true


### PR DESCRIPTION
firebase-functions@7.2.5의 peerDependency가 아직 firebase-admin@^13까지만 명시되어 CI npm ci 단계에서 충돌로 실패하던 문제 해소.