### PR TITLE
fix(functions): upgrade nodemailer 8→9 to resolve HIGH CVEs

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -9,7 +9,7 @@
                 "dotenv": "^16.5.0",
                 "firebase-admin": "^14.0.0",
                 "firebase-functions": "^7.2.5",
-                "nodemailer": "^8.0.7"
+                "nodemailer": "^9.0.1"
             },
             "engines": {
                 "node": "22"
@@ -177,9 +177,9 @@
             }
         },
         "node_modules/@google-cloud/storage": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.19.0.tgz",
-            "integrity": "sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==",
+            "version": "7.21.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.21.0.tgz",
+            "integrity": "sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
@@ -196,21 +196,10 @@
                 "mime": "^3.0.0",
                 "p-limit": "^3.0.1",
                 "retry-request": "^7.0.0",
-                "teeny-request": "^9.0.0",
-                "uuid": "^8.0.0"
+                "teeny-request": "^9.0.0"
             },
             "engines": {
                 "node": ">=14"
-            }
-        },
-        "node_modules/@google-cloud/storage/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "license": "MIT",
-            "optional": true,
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@grpc/grpc-js": {
@@ -345,12 +334,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
             "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/@protobufjs/inquire": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-            "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
@@ -1480,16 +1463,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "2.5.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-            "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+            "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
+                "hasown": "^2.0.4",
                 "mime-types": "^2.1.35",
                 "safe-buffer": "^5.2.1"
             },
@@ -1927,9 +1910,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -2504,9 +2487,9 @@
             }
         },
         "node_modules/nodemailer": {
-            "version": "8.0.7",
-            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
-            "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.1.tgz",
+            "integrity": "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==",
             "license": "MIT-0",
             "engines": {
                 "node": ">=6.0.0"
@@ -2667,9 +2650,9 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
-            "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
+            "version": "7.6.4",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+            "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -2679,7 +2662,6 @@
                 "@protobufjs/eventemitter": "^1.1.1",
                 "@protobufjs/fetch": "^1.1.1",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.2",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
                 "@protobufjs/utf8": "^1.1.1",

--- a/functions/package.json
+++ b/functions/package.json
@@ -7,6 +7,6 @@
         "dotenv": "^16.5.0",
         "firebase-admin": "^14.0.0",
         "firebase-functions": "^7.2.5",
-        "nodemailer": "^8.0.7"
+        "nodemailer": "^9.0.1"
     }
 }


### PR DESCRIPTION
## Summary

CI 배포가 `npm audit --audit-level=high --prefix functions` 에서 HIGH 취약점으로 실패하여 긴급 수정.

- `nodemailer ^8.0.7` → `^9.0.1` 업그레이드
  - GHSA-p6gq-j5cr-w38f: SSRF (HIGH)
  - GHSA-268h-hp4c-crq3: CRLF injection (HIGH)
  - GHSA-wqvq-jvpq-h66f: jsonTransport bypass (HIGH)
  - GHSA-r7g4-qg5f-qqm2: TLS 인증 우회 (HIGH)

사용 패턴은 `createTransport` + `sendMail` 기본 API만 — v9에서 breaking change 없음.

## Test plan

- [x] `npm audit --omit=dev --audit-level=high --prefix functions` → 0 vulnerabilities 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)