### PR TITLE
fix(security): prevent activity slug hijacking in DB rules

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -63,7 +63,7 @@
     "activitySlugs": {
       "$slug": {
         ".read": true,
-        ".write": "auth != null && (auth.token.role === 'admin' || auth.token.role === 'owner' || newData.val() == auth.uid || (!newData.exists() && data.val() == auth.uid))"
+        ".write": "auth != null && (auth.token.role === 'admin' || auth.token.role === 'owner' || (!data.exists() && newData.val() == auth.uid) || (!newData.exists() && data.val() == auth.uid))"
       }
     },
     "auditLogs": {


### PR DESCRIPTION
## Summary

- `activitySlugs` 쓰기 규칙에 `!data.exists()` 조건 추가
- 기존: 로그인 사용자가 이미 점유된 슬러그에 자신의 uid를 덮어쓰기 가능 (슬러그 탈취)
- 수정: 미점유 슬러그(`!data.exists()`)일 때만 새로 쓸 수 있도록 제한

## Test plan

- [x] 본인 슬러그 신규 등록 정상 동작 확인
- [x] 본인 슬러그 삭제 정상 동작 확인
- [x] 타인이 점유한 슬러그 덮어쓰기 시도 → 거부 확인
- [x] Firebase Console에서 `database.rules.json` 배포

🤖 Generated with [Claude Code](https://claude.com/claude-code)